### PR TITLE
travis: initial CI recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+notifications:
+  email: false
+
+sudo: true
+
+language: python
+
+cache:
+  - pip
+
+python:
+  - 2.7
+
+services:
+  - docker
+
+before_install:
+  - travis_retry pip install yadage
+
+install:
+  - docker build -t helloworld .
+
+script:
+  - yadage-validate helloworld.yaml | grep -q 'workflow validates'
+  - docker run -v `pwd`:/code -i -t --rm helloworld python helloworld.py --name Jim --sleeptime 1
+  - grep -q 'Hello Jim!' output/greetings.txt

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,15 @@
  REANA demo example - "hello world"
 ====================================
 
+.. image:: https://img.shields.io/travis/reanahub/reana-demo-helloworld.svg
+   :target: https://travis-ci.org/reanahub/reana-demo-helloworld
+
+.. image:: https://badges.gitter.im/Join%20Chat.svg
+   :target: https://gitter.im/reanahub/reana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+
+.. image:: https://img.shields.io/github/license/reanahub/reana-demo-helloworld.svg
+   :target: https://github.com/reanahub/reana-demo-helloworld/blob/master/COPYING
+
 About
 =====
 


### PR DESCRIPTION
* Adds the initial Travis CI recipe that builds the "hello world" example's
  Docker image and tests whether it works OK.

* The tests faithfully follow the docker-build-and-run steps presented in the
  README documentation. Moreover, the workflow definition (the Yadage YAML file)
  is also validated.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>