### PR TITLE
docs: virtualenv instead of mkvirtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,8 +163,10 @@ We can now install the REANA command-line client, run the analysis and download 
 
 .. code-block:: console
 
+    $ # create new virtual environment
+    $ virtualenv ~/.virtualenvs/myreana
+    $ source ~/.virtualenvs/myreana/bin/activate
     $ # install REANA client
-    $ mkvirtualenv reana-client
     $ pip install reana-client
     $ # connect to some REANA cloud instance
     $ export REANA_SERVER_URL=https://reana.cern.ch/


### PR DESCRIPTION
(connects reanahub/reana#106)

Signed-off-by: Jan Okraska <jan.okraska@cern.ch>