### PR TITLE
global: zero sleeptime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ The workflow can be represented as follows:
                 V
     +-------------------------------+
     |                               | <-- inputfile=data/names.txt
-    |    $ python helloworld.py ... | <-- sleeptime=2
+    |    $ python helloworld.py ... | <-- sleeptime=0
     +-------------------------------+
                 |
                 | otuputfile=results/greetings.txt
@@ -138,17 +138,20 @@ the computational workflow steps and the expected outputs:
         - code/helloworld.py
         - data/names.txt
       parameters:
-        sleeptime: 2
-        inputfile: data/names.txt
         helloworld: code/helloworld.py
+        inputfile: data/names.txt
         outputfile: results/greetings.txt
+        sleeptime: 0
     workflow:
       type: serial
       specification:
         steps:
           - environment: 'python:2.7'
             commands:
-              - python "${helloworld}" --sleeptime ${sleeptime} --inputfile "${inputfile}" --outputfile "${outputfile}"
+              - python "${helloworld}"
+                  --inputfile "${inputfile}"
+                  --outputfile "${outputfile}"
+                  --sleeptime ${sleeptime}
     outputs:
       files:
        - results/greetings.txt

--- a/code/helloworld.py
+++ b/code/helloworld.py
@@ -11,7 +11,7 @@ import sys
 import time
 
 
-def hello(inputfile="data/names.txt", outputfile="results/greetings.txt", sleeptime=1.0):
+def hello(inputfile="data/names.txt", outputfile="results/greetings.txt", sleeptime=0.0):
     """Say 'Hello' to given name and store the greeting to a file.
 
     Writes the greeting character by character. An optional waiting period

--- a/reana-yadage.yaml
+++ b/reana-yadage.yaml
@@ -4,7 +4,7 @@ inputs:
     - code/helloworld.py
     - data/names.txt
   parameters:
-    sleeptime: 2
+    sleeptime: 0
     inputfile: data/names.txt
     helloworld: code/helloworld.py
 workflow:

--- a/reana.yaml
+++ b/reana.yaml
@@ -4,17 +4,20 @@ inputs:
     - code/helloworld.py
     - data/names.txt
   parameters:
-    sleeptime: 2
-    inputfile: data/names.txt
     helloworld: code/helloworld.py
+    inputfile: data/names.txt
     outputfile: results/greetings.txt
+    sleeptime: 0
 workflow:
   type: serial
   specification:
     steps:
       - environment: 'python:2.7'
         commands:
-          - python "${helloworld}" --sleeptime ${sleeptime} --inputfile "${inputfile}" --outputfile "${outputfile}"
+          - python "${helloworld}"
+              --inputfile "${inputfile}"
+              --outputfile "${outputfile}"
+              --sleeptime ${sleeptime}
 outputs:
   files:
    - results/greetings.txt

--- a/workflow/cwl/helloworld-job.yml
+++ b/workflow/cwl/helloworld-job.yml
@@ -1,4 +1,4 @@
-sleeptime: 1
+sleeptime: 0
 helloworld:
   class: File
   location: code/helloworld.py

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -4,7 +4,7 @@
 #   $ mkdir -p yadage-local-run/yadage-inputs
 #   $ cd yadage-local-run
 #   $ cp -a ../code ../data yadage-inputs
-#   $ yadage-run . ../workflow/yadage/workflow.yaml -p sleeptime=2 \
+#   $ yadage-run . ../workflow/yadage/workflow.yaml -p sleeptime=0 \
 #       -p inputfile=data/names.txt \
 #       -p helloworld=code/helloworld.py \
 #       -d initdir=`pwd`/yadage-inputs


### PR DESCRIPTION
* Sets no sleeptime by default everywhere so that the example would be executed
  very fast. Useful for quick tests, since the container image itself is
  small. (E.g. ``reana-dev run-example -c r-d-helloworld -s 10``)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>