### PR TITLE
serial: Slurm compute backend example

### DIFF
--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -1,0 +1,25 @@
+version: 0.3.0
+inputs:
+  files:
+    - code/helloworld.py
+    - data/names.txt
+  parameters:
+    helloworld: code/helloworld.py
+    inputfile: data/names.txt
+    outputfile: results/greetings.txt
+    sleeptime: 0
+workflow:
+  type: serial
+  specification:
+    steps:
+      - name: reana_demo_helloworld_slurmcern
+        environment: 'python:2.7-slim'
+        compute_backend: slurmcern
+        commands:
+            - python "${helloworld}"
+                --inputfile "${inputfile}"
+                --outputfile "${outputfile}"
+                --sleeptime ${sleeptime}
+outputs:
+  files:
+   - results/greetings.txt


### PR DESCRIPTION
Note: the same runtime problems as for #48.

```console
$ reana-client logs -w hello-ser-hpc
...
==> Logs:
Auks API request failed : krb5 cred : unable to read credential cache
INFO:    Converting OCI blobs to SIF format
srun: error: hpc006: task 0: Exited with exit code 255
srun: Terminating job step 953513.0
FATAL:   Unable to handle docker://python:2.7-slim uri: while building SIF from layers: unable to create new build: while searching for mksquashfs: exec: "mksquashfs": executable file not found in $PATH
```