### PR TITLE
cwl: Slurm compute backend example

### DIFF
--- a/reana-cwl-slurmcern.yaml
+++ b/reana-cwl-slurmcern.yaml
@@ -1,0 +1,13 @@
+version: 0.3.0
+inputs:
+  files:
+    - code/helloworld.py
+    - data/names.txt
+  parameters:
+    input: workflow/cwl/helloworld-job.yml
+workflow:
+  type: cwl
+  file: workflow/cwl/helloworld-slurmcern.cwl
+outputs:
+  files:
+   - results/greetings.txt

--- a/workflow/cwl/helloworld-slurmcern.cwl
+++ b/workflow/cwl/helloworld-slurmcern.cwl
@@ -1,0 +1,46 @@
+#!/usr/bin/env cwl-runner
+
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#   $ mkdir cwl-local-run
+#   $ cd cwl-local-run
+#   $ cp ../code/* ../data/* ../workflow/cwl/helloworld-job.yml .
+#   $ cwltool --quiet --outdir="../outputs"
+#           ../workflow/cwl/helloworld.cwl helloworld-job.yml
+#   $ cat results/greetings.txt
+#   Hello Jane Doe!
+#   Hello Joe Bloggs!
+
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  helloworld: File
+  inputfile: File
+  sleeptime: int
+  outputfile:
+    type: string
+    default: results/greetings.txt
+
+outputs:
+  result:
+    type: File
+    outputSource: first/result
+
+steps:
+  first:
+    hints:
+      reana:
+        compute_backend: slurmcern
+    run: helloworld.tool
+    in:
+      helloworld: helloworld
+
+      inputfile: inputfile
+      sleeptime: sleeptime
+      outputfile: outputfile
+    out: [result]
+
+$namespaces:
+  reana: http://reana.io


### PR DESCRIPTION
The same singularity-related problems as in #49:

```console
$ reana-client logs -w hello-cwl-hpc
...
==> Logs:
Auks API request failed : krb5 cred : unable to read credential cache
INFO:    Converting OCI blobs to SIF format
srun: error: hpc005: task 0: Exited with exit code 255
srun: Terminating job step 953602.0
FATAL:   Unable to handle docker://python:2.7-slim uri: while building SIF from layers: unable to create new build: while searching for mksquashfs: exec: "mksquashfs": executable file not found in $PATH
```