### PR TITLE
tests: add technology-specific feature files

### DIFF
--- a/tests/cwl/log-messages.feature
+++ b/tests/cwl/log-messages.feature
@@ -1,0 +1,16 @@
+# Tests for the expected log messages
+
+Feature: Log messages
+
+    As a researcher,
+    I want to be able to see the log messages of my workflow execution,
+    So that I can verify that the workflow ran correctly.
+
+    Scenario: The workflow start has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "cwltool | MainThread | INFO | [workflow ] start"
+        Then the engine logs should contain "cwltool | MainThread | INFO | [step first] start"
+
+    Scenario: The workflow completion has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "cwltool | MainThread | INFO | Final process status is success"

--- a/tests/cwl/run-duration.feature
+++ b/tests/cwl/run-duration.feature
@@ -1,0 +1,11 @@
+# Tests for the duration of the workflow run
+
+Feature: Run duration
+
+    As a researcher,
+    I want to verify that my workflow finishes in a reasonable amount of time,
+    so that I can stay assured that there are no unusual problems with computing resources.
+
+    Scenario: The workflow terminates in a reasonable amount of time
+        When the workflow is finished
+        Then the workflow run duration should be less than 10 minutes

--- a/tests/cwl/workspace-files.feature
+++ b/tests/cwl/workspace-files.feature
@@ -1,0 +1,27 @@
+# Tests for the presence of the expected workflow files
+
+Feature: Workspace files
+
+    As a researcher,
+    I want to make sure that the workspace produces expected files,
+    so that I can be sure that the workflow outputs are correct.
+
+    Scenario: The workspace contains the expected input files
+        When the workflow is finished
+        Then the workspace should include "code/helloworld.py"
+        And the workspace should include "data/names.txt"
+
+    Scenario: The code used to generate the plot is correct
+        When the workflow is finished
+        Then the file "code/helloworld.py" should contain "message = "Hello " + name + "!\n""
+
+    Scenario: The people are correctly greeted
+        When the workflow is finished
+        Then the workspace should contain "outputs/greetings.txt"
+        And the size of the file "outputs/greetings.txt" should be between 30B and 40B
+        And the file "outputs/greetings.txt" should contain "Hello Jane Doe!"
+        And the file "outputs/greetings.txt" should contain "Hello Joe Bloggs!"
+
+    Scenario: The total workspace size remains within reasonable limits
+        When the workflow is finished
+        Then the workspace size should be less than 50MiB

--- a/tests/serial/log-messages.feature
+++ b/tests/serial/log-messages.feature
@@ -1,0 +1,11 @@
+# Tests for the expected log messages
+
+Feature: Log messages
+
+    As a researcher,
+    I want to be able to see the log messages of my workflow execution,
+    So that I can verify that the workflow ran correctly.
+
+    Scenario: The workflow start has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "Publishing step:0, cmd: python "code/helloworld.py""

--- a/tests/serial/run-duration.feature
+++ b/tests/serial/run-duration.feature
@@ -1,0 +1,11 @@
+# Tests for the duration of the workflow run
+
+Feature: Run duration
+
+    As a researcher,
+    I want to verify that my workflow finishes in a reasonable amount of time,
+    so that I can stay assured that there are no unusual problems with computing resources.
+
+    Scenario: The workflow terminates in a reasonable amount of time
+        When the workflow is finished
+        Then the workflow run duration should be less than 10 minutes

--- a/tests/serial/workspace-files.feature
+++ b/tests/serial/workspace-files.feature
@@ -1,0 +1,27 @@
+# Tests for the presence of the expected workflow files
+
+Feature: Workspace files
+
+    As a researcher,
+    I want to make sure that the workspace produces expected files,
+    so that I can be sure that the workflow outputs are correct.
+
+    Scenario: The workspace contains the expected input files
+        When the workflow is finished
+        Then the workspace should include "code/helloworld.py"
+        And the workspace should include "data/names.txt"
+
+    Scenario: The code used to generate the plot is correct
+        When the workflow is finished
+        Then the file "code/helloworld.py" should contain "message = "Hello " + name + "!\n""
+
+    Scenario: The people are correctly greeted
+        When the workflow is finished
+        Then the workspace should contain "results/greetings.txt"
+        And the size of the file "results/greetings.txt" should be between 30B and 40B
+        And the file "results/greetings.txt" should contain "Hello Jane Doe!"
+        And the file "results/greetings.txt" should contain "Hello Joe Bloggs!"
+
+    Scenario: The total workspace size remains within reasonable limits
+        When the workflow is finished
+        Then the workspace size should be less than 50MiB

--- a/tests/snakemake/log-messages.feature
+++ b/tests/snakemake/log-messages.feature
@@ -1,0 +1,15 @@
+# Tests for the expected log messages
+
+Feature: Log messages
+
+    As a researcher,
+    I want to be able to see the log messages of my workflow execution,
+    So that I can verify that the workflow ran correctly.
+
+    Scenario: The workflow start has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "snakemake.logging | MainThread | WARNING | Building DAG of jobs..."
+
+    Scenario: The workflow completion has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "snakemake.logging | MainThread | INFO | 2 of 2 steps (100%) done"

--- a/tests/snakemake/run-duration.feature
+++ b/tests/snakemake/run-duration.feature
@@ -1,0 +1,11 @@
+# Tests for the duration of the workflow run
+
+Feature: Run duration
+
+    As a researcher,
+    I want to verify that my workflow finishes in a reasonable amount of time,
+    so that I can stay assured that there are no unusual problems with computing resources.
+
+    Scenario: The workflow terminates in a reasonable amount of time
+        When the workflow is finished
+        Then the workflow run duration should be less than 10 minutes

--- a/tests/snakemake/workspace-files.feature
+++ b/tests/snakemake/workspace-files.feature
@@ -1,0 +1,27 @@
+# Tests for the presence of the expected workflow files
+
+Feature: Workspace files
+
+    As a researcher,
+    I want to make sure that the workspace produces expected files,
+    so that I can be sure that the workflow outputs are correct.
+
+    Scenario: The workspace contains the expected input files
+        When the workflow is finished
+        Then the workspace should include "code/helloworld.py"
+        And the workspace should include "data/names.txt"
+
+    Scenario: The code used to generate the plot is correct
+        When the workflow is finished
+        Then the file "code/helloworld.py" should contain "message = "Hello " + name + "!\n""
+
+    Scenario: The people are correctly greeted
+        When the workflow is finished
+        Then the workspace should contain "results/greetings.txt"
+        And the size of the file "results/greetings.txt" should be between 30B and 40B
+        And the file "results/greetings.txt" should contain "Hello Jane Doe!"
+        And the file "results/greetings.txt" should contain "Hello Joe Bloggs!"
+
+    Scenario: The total workspace size remains within reasonable limits
+        When the workflow is finished
+        Then the workspace size should be less than 50MiB

--- a/tests/yadage/log-messages.feature
+++ b/tests/yadage/log-messages.feature
@@ -1,0 +1,18 @@
+# Tests for the expected log messages
+
+Feature: Log messages
+
+    As a researcher,
+    I want to be able to see the log messages of my workflow execution,
+    So that I can verify that the workflow ran correctly.
+
+    Scenario: The workflow start has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "yadage.creators | MainThread | INFO | initializing workflow"
+        And the engine logs should contain "yadage.wflowview | MainThread | INFO | added </init:0|defined|unknown>"
+        And the engine logs should contain "yadage.wflowview | MainThread | INFO | added </helloworld:0|defined|unknown>"
+
+    Scenario: The workflow completion has produced the expected messages
+        When the workflow is finished
+        Then the engine logs should contain "adage | MainThread | INFO | workflow completed successfully."
+        And the engine logs should contain "adage | MainThread | INFO | execution valid. (in terms of execution order)"

--- a/tests/yadage/run-duration.feature
+++ b/tests/yadage/run-duration.feature
@@ -1,0 +1,11 @@
+# Tests for the duration of the workflow run
+
+Feature: Run duration
+
+    As a researcher,
+    I want to verify that my workflow finishes in a reasonable amount of time,
+    so that I can stay assured that there are no unusual problems with computing resources.
+
+    Scenario: The workflow terminates in a reasonable amount of time
+        When the workflow is finished
+        Then the workflow run duration should be less than 10 minutes

--- a/tests/yadage/workspace-files.feature
+++ b/tests/yadage/workspace-files.feature
@@ -1,0 +1,27 @@
+# Tests for the presence of the expected workflow files
+
+Feature: Workspace files
+
+    As a researcher,
+    I want to make sure that the workspace produces expected files,
+    so that I can be sure that the workflow outputs are correct.
+
+    Scenario: The workspace contains the expected input files
+        When the workflow is finished
+        Then the workspace should include "code/helloworld.py"
+        And the workspace should include "data/names.txt"
+
+    Scenario: The code used to generate the plot is correct
+        When the workflow is finished
+        Then the file "code/helloworld.py" should contain "message = "Hello " + name + "!\n""
+
+    Scenario: The people are correctly greeted
+        When the workflow is finished
+        Then the workspace should contain "helloworld/greetings.txt"
+        And the size of the file "helloworld/greetings.txt" should be between 30B and 40B
+        And the file "helloworld/greetings.txt" should contain "Hello Jane Doe!"
+        And the file "helloworld/greetings.txt" should contain "Hello Joe Bloggs!"
+
+    Scenario: The total workspace size remains within reasonable limits
+        When the workflow is finished
+        Then the workspace size should be less than 50MiB


### PR DESCRIPTION
Separates the test feature files into different subfolders depending on
the workflow engine (cwl, yadage, snakemake) used by the workflow. This
is needed to look for log messages that are relevant to the specific
workflow engine.
Tests that are valid for all the workflow engines are kept at the
highest level in the `tests` directory.
Changes the REANA specification files so that the output file is always
created in the same directory, regardless of the workflow engine.
