### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,40 @@
 name: ci
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 7 * * 1'
 
-lint-yamllint:
+jobs:
+  cwl-local-run:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run CWL locally
+        uses: reanahub/reana-github-actions/local-run@v1
         with:
-          fetch-depth: 0
+          commands: |
+            rm -rf cwl-local-run && mkdir -p cwl-local-run && cd cwl-local-run
+            pip install cwltool
+            cp -a ../code ../data . && cp ../workflow/cwl/helloworld-job.yml .
+            cwltool --quiet --outdir="./results" ../workflow/cwl/helloworld.cwl helloworld-job.yml
+            grep -q 'Hello Joe Bloggs!' results/greetings.txt
+            cd .. && rm -rf cwl-local-run
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+  cwl-validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate CWL spec
+        uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          python-version: "3.12"
+          reana_specs: reana-cwl*.yaml
 
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --lint-yamllint
-
-format-shfmt:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -37,12 +51,6 @@ format-shfmt:
           sudo apt-get install shfmt
           ./run-tests.sh --format-shfmt
 
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 7 * * 1'
-
-jobs:
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -69,6 +77,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -80,43 +102,21 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-  cwl-validate:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate CWL spec
-        uses: reanahub/reana-github-actions/local-validate@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          reana_specs: reana-cwl*.yaml
+          python-version: "3.12"
 
-  cwl-local-run:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run CWL locally
-        uses: reanahub/reana-github-actions/local-run@v1
-        with:
-          commands: |
-            rm -rf cwl-local-run && mkdir -p cwl-local-run && cd cwl-local-run
-            pip install cwltool
-            cp -a ../code ../data . && cp ../workflow/cwl/helloworld-job.yml .
-            cwltool --quiet --outdir="./results" ../workflow/cwl/helloworld.cwl helloworld-job.yml
-            grep -q 'Hello Joe Bloggs!' results/greetings.txt
-            cd .. && rm -rf cwl-local-run
-
-  serial-validate:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate serial spec
-        uses: reanahub/reana-github-actions/local-validate@v1
-        with:
-          reana_specs: reana.yaml reana-htcondorcern.yaml reana-slurmcern.yaml
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
 
   serial-local-run:
     runs-on: ubuntu-24.04
@@ -132,16 +132,16 @@ jobs:
             grep -q 'Hello Joe Bloggs!' results/greetings.txt
             rm -rf results
 
-  snakemake-validate:
+  serial-validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Snakemake spec
+      - name: Validate serial spec
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          reana_specs: reana-snakemake*.yaml
+          reana_specs: reana.yaml reana-htcondorcern.yaml reana-slurmcern.yaml
 
   snakemake-local-run:
     runs-on: ubuntu-24.04
@@ -159,16 +159,16 @@ jobs:
             grep -q 'Hello Joe Bloggs!' results/greetings.txt
             cd .. && rm -rf snakemake-local-run
 
-  yadage-validate:
+  snakemake-validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Yadage spec
+      - name: Validate Snakemake spec
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          reana_specs: reana-yadage*.yaml
+          reana_specs: reana-snakemake*.yaml
 
   yadage-local-run:
     runs-on: ubuntu-24.04
@@ -185,3 +185,14 @@ jobs:
             yadage-run . ../workflow/yadage/workflow.yaml -p sleeptime=0 -p inputfile=data/names.txt -p helloworld=code/helloworld.py -d initdir=`pwd`/yadage-inputs
             grep -q 'Hello Joe Bloggs!' helloworld/greetings.txt
             cd .. && rm -rf yadage-local-run
+
+  yadage-validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Yadage spec
+        uses: reanahub/reana-github-actions/local-validate@v1
+        with:
+          reana_specs: reana-yadage*.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@
 name: ci
 
 on:
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ lint-yamllint:
           pip install yamllint
           ./run-tests.sh --lint-yamllint
 
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2023, 2024 CERN.
+# Copyright (C) 2020, 2021, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on:
   push:
@@ -32,12 +32,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -48,7 +48,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   cwl-validate:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 7 * * 1'
+    - cron: "0 7 * * 1"
 
 jobs:
   cwl-local-run:
@@ -39,6 +39,20 @@ jobs:
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
           reana_specs: reana-cwl*.yaml
+
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
 
   format-shfmt:
     runs-on: ubuntu-24.04

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 ## About
 
 This repository provides a simple "hello world" application example for
-[REANA](http://www.reanahub.io/) reusable research data analysis plaftorm. The example
-generates greetings for persons specified in an input file.
+[REANA](http://www.reanahub.io/) reusable research data analysis plaftorm.
+The example generates greetings for persons specified in an input file.
 
 ## Analysis structure
 
-Making a research data analysis reproducible basically means to provide "runnable
-recipes" addressing (1) where is the input data, (2) what software was used to analyse
-the data, (3) which computing environments were used to run the software and (4) which
-computational workflow steps were taken to run the analysis. This will permit to
-instantiate the analysis on the computational cloud and run the analysis to obtain (5)
-output results.
+Making a research data analysis reproducible basically means to provide
+"runnable recipes" addressing (1) where is the input data, (2) what software
+was used to analyse the data, (3) which computing environments were used to
+run the software and (4) which computational workflow steps were taken to run
+the analysis. This will permit to instantiate the analysis on the
+computational cloud and run the analysis to obtain (5) output results.
 
 ### 1. Input dataset
 
@@ -36,8 +36,8 @@ A simple "hello world" Python code for illustration:
 
 - [helloworld.py](code/helloworld.py)
 
-The program takes an input file with the names of the persons to greet and an optional
-sleeptime period and produces an output file with the greetings:
+The program takes an input file with the names of the persons to greet and
+an optional sleeptime period and produces an output file with the greetings:
 
 ```console
 $ python code/helloworld.py \
@@ -51,10 +51,11 @@ Hello Joe Bloggs!
 
 ### 3. Compute environment
 
-In order to be able to rerun the analysis even several years in the future, we need to
-"encapsulate the current compute environment", for example to freeze the Jupyter notebook
-version and the notebook kernel that our analysis was using. We shall achieve this by
-preparing a [Docker](https://www.docker.com/) container image for our analysis steps.
+In order to be able to rerun the analysis even several years in the future,
+we need to "encapsulate the current compute environment", for example to
+freeze the Jupyter notebook version and the notebook kernel that our analysis
+was using. We shall achieve this by preparing a
+[Docker](https://www.docker.com/) container image for our analysis steps.
 
 For example:
 
@@ -63,14 +64,15 @@ $ cat environments/python/Dockerfile
 FROM docker.io/library/python:2.7-slim
 ```
 
-Since we don't need any additional Python packages for this simple example to work, we
-can directly rely on the `python` image from the Docker Hub. The trailing `:2.7-slim`
-makes sure we are using the Python 2.7 slim image version.
+Since we don't need any additional Python packages for this simple example
+to work, we can directly rely on the `python` image from the Docker Hub.
+The trailing `:2.7-slim` makes sure we are using the Python 2.7 slim image
+version.
 
 ### 4. Analysis workflow
 
-This analysis is very simple because it consists basically of running only the Python
-executable which will produce a text file.
+This analysis is very simple because it consists basically of running only
+the Python executable which will produce a text file.
 
 The workflow can be represented as follows:
 
@@ -90,8 +92,8 @@ The workflow can be represented as follows:
 ```
 
 Note that you can also use [CWL](http://www.commonwl.org/v1.0/),
-[Yadage](https://github.com/diana-hep/yadage) or [Snakemake](https://snakemake.github.io)
-workflow specifications:
+[Yadage](https://github.com/diana-hep/yadage) or
+[Snakemake](https://snakemake.github.io) workflow specifications:
 
 - [Yadage workflow definition](workflow/yadage/workflow.yaml)
 - [CWL workflow definition](workflow/cwl/helloworld.cwl)
@@ -109,14 +111,15 @@ Hello Joe Bloggs!
 
 ## Running the above example on REANA
 
-We are now ready to run this example and on the [REANA](http://www.reana.io/) platform.
+We are now ready to run this example and on the
+[REANA](http://www.reana.io/) platform.
 
 There are two ways to execute this analysis example on REANA.
 
-If you would like to simply launch this analysis example on the REANA instance at CERN
-and inspect its results using the web interface, please click on one of the following
-badges, depending on which workflow system (CWL, Serial, Snakemake, Yadage) you would
-like to use:
+If you would like to simply launch this analysis example on the REANA
+instance at CERN and inspect its results using the web interface, please
+click on one of the following badges, depending on which workflow system
+(CWL, Serial, Snakemake, Yadage) you would like to use:
 
 [![Launch with CWL on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-cwl-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-helloworld&specification=reana-cwl.yaml&name=reana-demo-helloworld-cwl)
 
@@ -126,14 +129,14 @@ like to use:
 
 [![Launch with Yadage on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-yadage-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-helloworld&specification=reana-yadage.yaml&name=reana-demo-helloworld-yadage)
 
-If you would like a step-by-step guide on how to use the REANA command-line client to
-launch this analysis example, please read on.
+If you would like a step-by-step guide on how to use the REANA
+command-line client to launch this analysis example, please read on.
 
 ### Prepare files
 
-First we need to create a [reana.yaml](reana.yaml) file describing the structure of our
-analysis with its inputs, the code, the runtime environment, the computational workflow
-steps and the expected outputs:
+First we need to create a [reana.yaml](reana.yaml) file describing the
+structure of our analysis with its inputs, the code, the runtime
+environment, the computational workflow steps and the expected outputs:
 
 ```yaml
 version: 0.3.0
@@ -195,5 +198,6 @@ $ # download output results
 $ reana-client download results/greetings.txt
 ```
 
-Please see the [REANA-Client](https://reana-client.readthedocs.io/) documentation for
-more detailed explanation of typical `reana-client` usage scenarios.
+Please see the [REANA-Client](https://reana-client.readthedocs.io/)
+documentation for more detailed explanation of typical `reana-client` usage
+scenarios.

--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@
 ## About
 
 This repository provides a simple "hello world" application example for
-[REANA](http://www.reanahub.io/) reusable research data analysis plaftorm.
-The example generates greetings for persons specified in an input file.
+[REANA](http://www.reanahub.io/) reusable research data analysis plaftorm. The
+example generates greetings for persons specified in an input file.
 
 ## Analysis structure
 
 Making a research data analysis reproducible basically means to provide
-"runnable recipes" addressing (1) where is the input data, (2) what software
-was used to analyse the data, (3) which computing environments were used to
-run the software and (4) which computational workflow steps were taken to run
-the analysis. This will permit to instantiate the analysis on the
-computational cloud and run the analysis to obtain (5) output results.
+"runnable recipes" addressing (1) where is the input data, (2) what software was
+used to analyse the data, (3) which computing environments were used to run the
+software and (4) which computational workflow steps were taken to run the
+analysis. This will permit to instantiate the analysis on the computational
+cloud and run the analysis to obtain (5) output results.
 
 ### 1. Input dataset
 
@@ -36,8 +36,8 @@ A simple "hello world" Python code for illustration:
 
 - [helloworld.py](code/helloworld.py)
 
-The program takes an input file with the names of the persons to greet and
-an optional sleeptime period and produces an output file with the greetings:
+The program takes an input file with the names of the persons to greet and an
+optional sleeptime period and produces an output file with the greetings:
 
 ```console
 $ python code/helloworld.py \
@@ -51,11 +51,11 @@ Hello Joe Bloggs!
 
 ### 3. Compute environment
 
-In order to be able to rerun the analysis even several years in the future,
-we need to "encapsulate the current compute environment", for example to
-freeze the Jupyter notebook version and the notebook kernel that our analysis
-was using. We shall achieve this by preparing a
-[Docker](https://www.docker.com/) container image for our analysis steps.
+In order to be able to rerun the analysis even several years in the future, we
+need to "encapsulate the current compute environment", for example to freeze the
+Jupyter notebook version and the notebook kernel that our analysis was using. We
+shall achieve this by preparing a [Docker](https://www.docker.com/) container
+image for our analysis steps.
 
 For example:
 
@@ -64,15 +64,14 @@ $ cat environments/python/Dockerfile
 FROM docker.io/library/python:2.7-slim
 ```
 
-Since we don't need any additional Python packages for this simple example
-to work, we can directly rely on the `python` image from the Docker Hub.
-The trailing `:2.7-slim` makes sure we are using the Python 2.7 slim image
-version.
+Since we don't need any additional Python packages for this simple example to
+work, we can directly rely on the `python` image from the Docker Hub. The
+trailing `:2.7-slim` makes sure we are using the Python 2.7 slim image version.
 
 ### 4. Analysis workflow
 
-This analysis is very simple because it consists basically of running only
-the Python executable which will produce a text file.
+This analysis is very simple because it consists basically of running only the
+Python executable which will produce a text file.
 
 The workflow can be represented as follows:
 
@@ -111,15 +110,15 @@ Hello Joe Bloggs!
 
 ## Running the above example on REANA
 
-We are now ready to run this example and on the
-[REANA](http://www.reana.io/) platform.
+We are now ready to run this example and on the [REANA](http://www.reana.io/)
+platform.
 
 There are two ways to execute this analysis example on REANA.
 
-If you would like to simply launch this analysis example on the REANA
-instance at CERN and inspect its results using the web interface, please
-click on one of the following badges, depending on which workflow system
-(CWL, Serial, Snakemake, Yadage) you would like to use:
+If you would like to simply launch this analysis example on the REANA instance
+at CERN and inspect its results using the web interface, please click on one of
+the following badges, depending on which workflow system (CWL, Serial,
+Snakemake, Yadage) you would like to use:
 
 [![Launch with CWL on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-cwl-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-helloworld&specification=reana-cwl.yaml&name=reana-demo-helloworld-cwl)
 
@@ -129,14 +128,14 @@ click on one of the following badges, depending on which workflow system
 
 [![Launch with Yadage on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-yadage-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-helloworld&specification=reana-yadage.yaml&name=reana-demo-helloworld-yadage)
 
-If you would like a step-by-step guide on how to use the REANA
-command-line client to launch this analysis example, please read on.
+If you would like a step-by-step guide on how to use the REANA command-line
+client to launch this analysis example, please read on.
 
 ### Prepare files
 
-First we need to create a [reana.yaml](reana.yaml) file describing the
-structure of our analysis with its inputs, the code, the runtime
-environment, the computational workflow steps and the expected outputs:
+First we need to create a [reana.yaml](reana.yaml) file describing the structure
+of our analysis with its inputs, the code, the runtime environment, the
+computational workflow steps and the expected outputs:
 
 ```yaml
 version: 0.3.0
@@ -153,15 +152,13 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/library/python:2.7-slim'
+      - environment: "docker.io/library/python:2.7-slim"
         commands:
-          - python "${helloworld}"
-              --inputfile "${inputfile}"
-              --outputfile "${outputfile}"
-              --sleeptime ${sleeptime}
+          - python "${helloworld}" --inputfile "${inputfile}" --outputfile
+            "${outputfile}" --sleeptime ${sleeptime}
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt
 ```
 
 In case you are using CWL, Yadage or Snakemake workflow specifications:

--- a/reana-cwl-htcondorcern.yaml
+++ b/reana-cwl-htcondorcern.yaml
@@ -10,4 +10,4 @@ workflow:
   file: workflow/cwl/helloworld-htcondorcern.cwl
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt

--- a/reana-cwl-slurmcern.yaml
+++ b/reana-cwl-slurmcern.yaml
@@ -10,4 +10,4 @@ workflow:
   file: workflow/cwl/helloworld-slurmcern.cwl
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt

--- a/reana-cwl.yaml
+++ b/reana-cwl.yaml
@@ -12,7 +12,7 @@ workflow:
   file: workflow/cwl/helloworld.cwl
 outputs:
   files:
-   - outputs/greetings.txt
+    - outputs/greetings.txt
 tests:
   files:
     - tests/cwl/log-messages.feature

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -13,14 +13,12 @@ workflow:
   specification:
     steps:
       - name: reana_demo_helloworld_htcondorcern
-        environment: 'docker.io/library/python:2.7-slim'
+        environment: "docker.io/library/python:2.7-slim"
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:
-            - python "${helloworld}"
-                --inputfile "${inputfile}"
-                --outputfile "${outputfile}"
-                --sleeptime ${sleeptime}
+          - python "${helloworld}" --inputfile "${inputfile}" --outputfile
+            "${outputfile}" --sleeptime ${sleeptime}
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -13,13 +13,11 @@ workflow:
   specification:
     steps:
       - name: reana_demo_helloworld_slurmcern
-        environment: 'docker.io/library/python:2.7-slim'
+        environment: "docker.io/library/python:2.7-slim"
         compute_backend: slurmcern
         commands:
-            - python "${helloworld}"
-                --inputfile "${inputfile}"
-                --outputfile "${outputfile}"
-                --sleeptime ${sleeptime}
+          - python "${helloworld}" --inputfile "${inputfile}" --outputfile
+            "${outputfile}" --sleeptime ${sleeptime}
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt

--- a/reana-snakemake-htcondorcern.yaml
+++ b/reana-snakemake-htcondorcern.yaml
@@ -12,4 +12,4 @@ workflow:
   file: workflow/snakemake/Snakefile-htcondorcern
 outputs:
   files:
-  - results/greetings.txt
+    - results/greetings.txt

--- a/reana-snakemake-slurmcern.yaml
+++ b/reana-snakemake-slurmcern.yaml
@@ -12,4 +12,4 @@ workflow:
   file: workflow/snakemake/Snakefile-slurmcern
 outputs:
   files:
-  - results/greetings.txt
+    - results/greetings.txt

--- a/reana-snakemake.yaml
+++ b/reana-snakemake.yaml
@@ -12,7 +12,7 @@ workflow:
   file: workflow/snakemake/Snakefile
 outputs:
   files:
-  - results/greetings.txt
+    - results/greetings.txt
 tests:
   files:
     - tests/snakemake/log-messages.feature

--- a/reana-yadage-htcondorcern.yaml
+++ b/reana-yadage-htcondorcern.yaml
@@ -14,4 +14,4 @@ workflow:
   file: workflow/yadage/workflow-htcondorcern.yaml
 outputs:
   files:
-  - helloworld/greetings.txt
+    - helloworld/greetings.txt

--- a/reana-yadage-slurmcern.yaml
+++ b/reana-yadage-slurmcern.yaml
@@ -14,4 +14,4 @@ workflow:
   file: workflow/yadage/workflow-slurmcern.yaml
 outputs:
   files:
-  - helloworld/greetings.txt
+    - helloworld/greetings.txt

--- a/reana-yadage.yaml
+++ b/reana-yadage.yaml
@@ -14,7 +14,7 @@ workflow:
   file: workflow/yadage/workflow.yaml
 outputs:
   files:
-  - helloworld/greetings.txt
+    - helloworld/greetings.txt
 tests:
   files:
     - tests/yadage/log-messages.feature

--- a/reana.yaml
+++ b/reana.yaml
@@ -12,15 +12,13 @@ workflow:
   type: serial
   specification:
     steps:
-      - environment: 'docker.io/library/python:2.7-slim'
+      - environment: "docker.io/library/python:2.7-slim"
         commands:
-          - python "${helloworld}"
-              --inputfile "${inputfile}"
-              --outputfile "${outputfile}"
-              --sleeptime ${sleeptime}
+          - python "${helloworld}" --inputfile "${inputfile}" --outputfile
+            "${outputfile}" --sleeptime ${sleeptime}
 outputs:
   files:
-   - results/greetings.txt
+    - results/greetings.txt
 tests:
   files:
     - tests/serial/log-messages.feature

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -35,7 +39,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -56,6 +60,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -65,6 +70,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -80,6 +86,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -64,6 +68,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -75,6 +80,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -92,6 +98,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,9 +51,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -63,6 +68,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -76,5 +82,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,6 +51,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -62,6 +66,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -69,12 +74,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -88,6 +94,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2017, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,15 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,23 +47,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/workflow/yadage/workflow-htcondorcern.yaml
+++ b/workflow/yadage/workflow-htcondorcern.yaml
@@ -16,24 +16,26 @@ stages:
   - name: helloworld
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        sleeptime: {step: init, output: sleeptime}
-        inputfile: {step: init, output: inputfile}
-        helloworld: {step: init, output: helloworld}
-        outputfile: '{workdir}/greetings.txt'
+        sleeptime: { step: init, output: sleeptime }
+        inputfile: { step: init, output: inputfile }
+        helloworld: { step: init, output: helloworld }
+        outputfile: "{workdir}/greetings.txt"
       step:
         process:
-          process_type: 'string-interpolated-cmd'
-          cmd: 'python "{helloworld}" --sleeptime {sleeptime} --inputfile "{inputfile}" --outputfile "{outputfile}"'
+          process_type: "string-interpolated-cmd"
+          cmd:
+            'python "{helloworld}" --sleeptime {sleeptime} --inputfile
+            "{inputfile}" --outputfile "{outputfile}"'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             outputfile: outputfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/library/python'
-          imagetag: '2.7-slim'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/library/python"
+          imagetag: "2.7-slim"
           resources:
             - compute_backend: htcondorcern
             - htcondor_max_runtime: espresso

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -16,23 +16,25 @@ stages:
   - name: helloworld
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        sleeptime: {step: init, output: sleeptime}
-        inputfile: {step: init, output: inputfile}
-        helloworld: {step: init, output: helloworld}
-        outputfile: '{workdir}/greetings.txt'
+        sleeptime: { step: init, output: sleeptime }
+        inputfile: { step: init, output: inputfile }
+        helloworld: { step: init, output: helloworld }
+        outputfile: "{workdir}/greetings.txt"
       step:
         process:
-          process_type: 'string-interpolated-cmd'
-          cmd: 'python "{helloworld}" --sleeptime {sleeptime} --inputfile "{inputfile}" --outputfile "{outputfile}"'
+          process_type: "string-interpolated-cmd"
+          cmd:
+            'python "{helloworld}" --sleeptime {sleeptime} --inputfile
+            "{inputfile}" --outputfile "{outputfile}"'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             outputfile: outputfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/library/python'
-          imagetag: '2.7-slim'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/library/python"
+          imagetag: "2.7-slim"
           resources:
             - compute_backend: slurmcern

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -16,21 +16,23 @@ stages:
   - name: helloworld
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        sleeptime: {step: init, output: sleeptime}
-        inputfile: {step: init, output: inputfile}
-        helloworld: {step: init, output: helloworld}
-        outputfile: '{workdir}/greetings.txt'
+        sleeptime: { step: init, output: sleeptime }
+        inputfile: { step: init, output: inputfile }
+        helloworld: { step: init, output: helloworld }
+        outputfile: "{workdir}/greetings.txt"
       step:
         process:
-          process_type: 'string-interpolated-cmd'
-          cmd: 'python "{helloworld}" --sleeptime {sleeptime} --inputfile "{inputfile}" --outputfile "{outputfile}"'
+          process_type: "string-interpolated-cmd"
+          cmd:
+            'python "{helloworld}" --sleeptime {sleeptime} --inputfile
+            "{inputfile}" --outputfile "{outputfile}"'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             outputfile: outputfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/library/python'
-          imagetag: '2.7-slim'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/library/python"
+          imagetag: "2.7-slim"


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.