### PR TITLE
feat(workflow): declare shared CWL tool file

### DIFF
--- a/reana-cwl-htcondorcern.yaml
+++ b/reana-cwl-htcondorcern.yaml
@@ -8,6 +8,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/helloworld-htcondorcern.cwl
+  files:
+    - workflow/cwl/helloworld.tool
 outputs:
   files:
     - results/greetings.txt

--- a/reana-cwl-slurmcern.yaml
+++ b/reana-cwl-slurmcern.yaml
@@ -8,6 +8,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/helloworld-slurmcern.cwl
+  files:
+    - workflow/cwl/helloworld.tool
 outputs:
   files:
     - results/greetings.txt

--- a/reana-cwl.yaml
+++ b/reana-cwl.yaml
@@ -10,6 +10,8 @@ inputs:
 workflow:
   type: cwl
   file: workflow/cwl/helloworld.cwl
+  files:
+    - workflow/cwl/helloworld.tool
 outputs:
   files:
     - outputs/greetings.txt


### PR DESCRIPTION
Add workflow/cwl/helloworld.tool to workflow.files in all three CWL
variants so that new REANA clients using server-side workflow loading
and validation include it in the workflow specification bundle.

Older REANA clients resolve this import while packing the CWL
specification before sending it to the server.

Closes reanahub/reana-workflow-validator#8